### PR TITLE
motion text processors

### DIFF
--- a/src/main/java/com/wdiscute/libtooltips/BobEffect.java
+++ b/src/main/java/com/wdiscute/libtooltips/BobEffect.java
@@ -1,0 +1,14 @@
+package com.wdiscute.libtooltips;
+
+import net.minecraft.network.chat.MutableComponent;
+import net.minecraft.world.entity.Entity;
+import net.minecraft.world.item.ItemStack;
+
+public class BobEffect
+{
+    public static MutableComponent process(String text, ItemStack stack, Entity entity)
+    {
+        // amplitude = bob height in pixels, wave = seconds per cycle
+        return MotionEffect.build(MotionEffect.Type.BOB, text, stack, entity, 1f, 2.5f);
+    }
+}

--- a/src/main/java/com/wdiscute/libtooltips/MotionEffect.java
+++ b/src/main/java/com/wdiscute/libtooltips/MotionEffect.java
@@ -1,0 +1,155 @@
+package com.wdiscute.libtooltips;
+
+import net.minecraft.network.chat.Component;
+import net.minecraft.network.chat.MutableComponent;
+import net.minecraft.network.chat.contents.PlainTextContents;
+import net.minecraft.util.FormattedCharSequence;
+import net.minecraft.world.entity.Entity;
+import net.minecraft.world.item.ItemStack;
+
+import java.util.ArrayList;
+import java.util.List;
+
+public class MotionEffect
+{
+    private static final String MARKER = "LTFX:";
+
+    public enum Type
+    {
+        BOB, ROTATE
+    }
+
+    public record Entry(Type type, float amplitude, float wave, double offset) {}
+
+    // motion components shared logic
+    // amplitude means bob height in pixels or rotate in degrees.
+    public static MutableComponent build(Type type, String text, ItemStack stack, Entity entity, float defaultAmplitude, float defaultWave)
+    {
+        float amplitude = defaultAmplitude;
+        float wave = defaultWave;
+        float phase = 1f;
+        boolean uniform = false;
+
+        String remaining = text;
+        while (true)
+        {
+            int semi = remaining.indexOf(';');
+            if (semi < 0)
+                break;
+
+            String option = remaining.substring(0, semi);
+            boolean matched = true;
+            try
+            {
+                if (option.equals("uniform")) uniform = true;
+                else if (option.startsWith("amplitude=")) amplitude = Float.parseFloat(option.substring(10));
+                else if (option.startsWith("angle=")) amplitude = Float.parseFloat(option.substring(6));
+                else if (option.startsWith("a=")) amplitude = Float.parseFloat(option.substring(2));
+                else if (option.startsWith("wave=")) wave = Float.parseFloat(option.substring(5));
+                else if (option.startsWith("w=")) wave = Float.parseFloat(option.substring(2));
+                else if (option.startsWith("phase=")) phase = Float.parseFloat(option.substring(6));
+                else if (option.startsWith("p=")) phase = Float.parseFloat(option.substring(2));
+                else matched = false;
+            } catch (NumberFormatException e) { matched = false; }
+
+            if (!matched)
+                break;
+
+            remaining = remaining.substring(semi + 1);
+        }
+
+        String content = remaining;
+
+        MutableComponent resolved = Tooltips.resolveTagsToComponent(content, stack, entity);
+
+        List<MutableComponent> chars = flattenToChars(resolved);
+
+        MutableComponent result = Component.empty();
+        int length = chars.size();
+        for (int i = 0; i < length; i++)
+        {
+            double offset = length <= 1 ? 0 : phase * i / (length - 1);
+
+            MutableComponent c = chars.get(i);
+            String marker = buildMarker(type, amplitude, wave, uniform ? 0 : offset);
+
+            result.append(c.setStyle(c.getStyle().withInsertion(marker)));
+        }
+
+        return result;
+    }
+
+    public static String buildMarker(Type type, float amplitude, float wave, double offset)
+    {
+        return MARKER + type.name().toLowerCase() + ":a=" + amplitude + ",w=" + wave + ",o=" + offset;
+    }
+
+    public static boolean hasMotion(FormattedCharSequence sequence)
+    {
+        boolean[] found = {false};
+
+        sequence.accept((index, style, codePoint) ->
+        {
+            String insertion = style.getInsertion();
+            if (insertion != null && insertion.startsWith(MARKER))
+            {
+                found[0] = true;
+                return false;
+            }
+            return true;
+        });
+
+        return found[0];
+    }
+
+    public static Entry parse(String insertion)
+    {
+        if (insertion == null || !insertion.startsWith(MARKER))
+            return null;
+
+        String[] kv = insertion.substring(MARKER.length()).split(":", 2);
+        if (kv.length < 2)
+            return null;
+
+        Type type = kv[0].equalsIgnoreCase("rotate") ? Type.ROTATE : Type.BOB;
+        float amplitude = 0f;
+        float wave = 1f;
+        double offset = 0;
+
+        for (String option : kv[1].split(","))
+        {
+            try
+            {
+                if (option.startsWith("a="))
+                    amplitude = Float.parseFloat(option.substring(2));
+                else if (option.startsWith("w="))
+                    wave = Float.parseFloat(option.substring(2));
+                else if (option.startsWith("o="))
+                    offset = Double.parseDouble(option.substring(2));
+            } catch (NumberFormatException ignored) {}
+        }
+
+        return new Entry(type, amplitude, wave, offset);
+    }
+
+    // flattens the possibly nested translation key ie a color/rgb inside motion tag
+    public static List<MutableComponent> flattenToChars(Component component)
+    {
+        List<MutableComponent> out = new ArrayList<>();
+        flatten(component, out);
+        return out;
+    }
+
+    private static void flatten(Component component, List<MutableComponent> out)
+    {
+        if (component.getContents() instanceof PlainTextContents plain)
+        {
+            String text = plain.text();
+            for (int i = 0; i < text.length(); i++)
+                out.add(Component.literal(String.valueOf(text.charAt(i))).withStyle(component.getStyle()));
+        }
+
+        for (Component sibling : component.getSiblings())
+            flatten(sibling, out);
+    }
+}

--- a/src/main/java/com/wdiscute/libtooltips/RotateEffect.java
+++ b/src/main/java/com/wdiscute/libtooltips/RotateEffect.java
@@ -1,0 +1,14 @@
+package com.wdiscute.libtooltips;
+
+import net.minecraft.network.chat.MutableComponent;
+import net.minecraft.world.entity.Entity;
+import net.minecraft.world.item.ItemStack;
+
+public class RotateEffect
+{
+    public static MutableComponent process(String text, ItemStack stack, Entity entity)
+    {
+        // amplitude = swing in degrees, wave = seconds per cycle
+        return MotionEffect.build(MotionEffect.Type.ROTATE, text, stack, entity, 15f, 4f);
+    }
+}

--- a/src/main/java/com/wdiscute/libtooltips/Tooltips.java
+++ b/src/main/java/com/wdiscute/libtooltips/Tooltips.java
@@ -63,6 +63,8 @@ public class Tooltips
             registerProcessor("ltkeybind", KeybindProcessor::process);
             registerProcessor("ltrgb", RGBEffect::process);
             registerProcessor("ltcolor", ColorEffect::process);
+            registerProcessor("ltbob", BobEffect::process);
+            registerProcessor("ltrotate", RotateEffect::process);
         }
 
         public static void registerKeybinds(RegisterKeyMappingsEvent event)

--- a/src/main/java/com/wdiscute/libtooltips/mixin/ClientTextTooltipMixin.java
+++ b/src/main/java/com/wdiscute/libtooltips/mixin/ClientTextTooltipMixin.java
@@ -1,0 +1,70 @@
+package com.wdiscute.libtooltips.mixin;
+
+import com.wdiscute.libtooltips.MotionEffect;
+import net.minecraft.client.gui.Font;
+import net.minecraft.client.gui.screens.inventory.tooltip.ClientTextTooltip;
+import net.minecraft.client.renderer.MultiBufferSource;
+import net.minecraft.util.FormattedCharSequence;
+import org.joml.Matrix4f;
+import org.spongepowered.asm.mixin.Final;
+import org.spongepowered.asm.mixin.Mixin;
+import org.spongepowered.asm.mixin.Shadow;
+import org.spongepowered.asm.mixin.injection.At;
+import org.spongepowered.asm.mixin.injection.Inject;
+import org.spongepowered.asm.mixin.injection.callback.CallbackInfo;
+
+@Mixin(ClientTextTooltip.class)
+public abstract class ClientTextTooltipMixin
+{
+    @Shadow
+    @Final
+    private FormattedCharSequence text;
+
+    // fall back to vanilla drawInBatch when no motion effects are present
+    // translation key can only carry one motion effect at a time (similar to existing api)
+    @Inject(method = "renderText", at = @At("HEAD"), cancellable = true)
+    private void libtooltips$renderMotion(Font font, int x, int y, Matrix4f pose, MultiBufferSource.BufferSource bufferSource, CallbackInfo ci)
+    {
+        if (!MotionEffect.hasMotion(this.text))
+            return;
+
+        ci.cancel();
+
+        double time = System.currentTimeMillis() / 1000.0;
+        float[] cursorX = {x};
+        Matrix4f charPose = new Matrix4f();
+
+        this.text.accept((index, style, codePoint) ->
+        {
+            MotionEffect.Entry entry = MotionEffect.parse(style.getInsertion());
+
+            FormattedCharSequence single = FormattedCharSequence.codepoint(codePoint, style);
+            // advance by true width, avoids the extra spacing that occurs from drawInBatch and results in failure to wrap
+            float advance = font.width(single);
+
+            charPose.set(pose);
+
+            if (entry != null)
+            {
+                double diff = entry.amplitude() * Math.sin(2 * Math.PI * ((time + entry.offset()) / entry.wave()));
+                if (entry.type() == MotionEffect.Type.ROTATE)
+                {
+                    float pivotX = cursorX[0] + advance / 2f;
+
+                    charPose.translate(pivotX, y, 0);
+                    charPose.rotateZ((float) Math.toRadians(diff));
+                    charPose.translate(-pivotX, -y, 0);
+                }
+                else
+                {
+                    charPose.translate(0, (float) diff, 0);
+                }
+            }
+
+            font.drawInBatch(single, cursorX[0], y, -1, true, charPose, bufferSource, Font.DisplayMode.NORMAL, 0, 15728880);
+            cursorX[0] += advance;
+
+            return true;
+        });
+    }
+}

--- a/src/main/resources/libtooltips.mixins.json
+++ b/src/main/resources/libtooltips.mixins.json
@@ -9,6 +9,7 @@
     "defaultRequire": 1
   },
   "client": [
-    "GetNameMixin"
+    "GetNameMixin",
+    "ClientTextTooltipMixin"
   ]
 }


### PR DESCRIPTION
Hi I have recently been using libtooltips for a mod of mine and have been enjoying it, however I felt it lacked the ability to provide some more control for tooltips that I really wanted to stand out to the player and thought this would be a good addition.

Added two new text processors that both share some functionality: 
### `<ltbob>`
`a` or `angle` or `amplitude` - Determines the max height a character reaches.
`w` or `wave` - Determines the frequency, higher being a slower animation and vice versa.
### `<ltrotate>`
`a` or `angle` or `amplitude` - Determines the angle of the max rotation a character reaches.
`w` or `wave` - Determines the frequency, higher being a slower animation and vice versa.

Both can be used outside of a color/rgb text processor for stacked effects. Here's what it currently looks like: 

https://github.com/user-attachments/assets/64959591-2b29-40e4-bb9f-0b8b5e43d52f

And the translation keys that made it: 
```
"tooltip.always.minecraft.diamond.0": "<ltbob>Default Bobbing</ltbob> with bonus!",
"tooltip.always.minecraft.diamond.1": "<ltrotate>Default Wobble</ltrotate>",
"tooltip.always.minecraft.diamond.2": "<ltbob>a=4;w=0.5;Strong Bobble</ltbob>",
"tooltip.always.minecraft.diamond.3": "<ltbob>a=2;w=5;<ltcolor>c=ffa21f;c=0e3d34;c=34ebc9;p=1;w=10;Nested Color Bob with color!</ltcolor></ltbob> and nothing!",
"tooltip.always.minecraft.diamond.4": "<ltrotate>a=60;w=2;<ltrgb>Super Abrasive Tooltip!</ltrgb></ltrotate>",
```